### PR TITLE
Travis CI: Use default script and default JVM options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
-env:
-  - SBT_OPTS="-Xmx2048M -Xss4M -XX:MaxPermSize=256M"
-install:
-  - sbt update
 scala:
   - 2.10.2
+before_install:
+  # Remove local .jvmopts file to run sbt-extras with 
+  # Travis default JVM options (stored in /etc/sbt/jvmopts)
+  - rm .jvmopts


### PR DESCRIPTION
I'm happy to see that you quickly found how to fix your Travis builds, after I had to interrupt our IRC discussion.

The misleading "pitfall" was that Travis `sbt` also relies on awesome `sbt-extras` and your very bigheap tuning defined in `.jvmopts` is (at the moment) not affordable on 3G Travis VMs. If you remove `.jvmopts`, then your project smoothly builds with the default settings. This way, I think that your `.travis.yml` is quite more simple and even ready to benefit from possible improvements on Travis virtual hardware in the future.
