### PR TITLE
go brace-free with -Yindent-colons

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ scalacOptions ++= Seq(
   "-deprecation",
   "-feature",
   "-Xfatal-warnings",
+  "-Yindent-colons",
   // re-test with every version bump. as of 3.0.0-M2 I'm reluctant to
   // enable it because on BigInt,  "Alphanumeric method to is not declared @infix"
   // (https://github.com/lampepfl/dotty/issues/10383)

--- a/src/main/scala/net/tisue/euler/Primes.scala
+++ b/src/main/scala/net/tisue/euler/Primes.scala
@@ -37,7 +37,7 @@ object Primes:
   // amount of primes you will need.
   var sieve = Array(false, false, true, true)
   private val lock = AnyRef()
-  def isSievedPrime(n: Int): Boolean = lock.synchronized {
+  def isSievedPrime(n: Int): Boolean = lock.synchronized:
     while n >= sieve.length do
       val newSieve = Array.fill(sieve.length * 2)(true)
       Array.copy(sieve, 0, newSieve, 0, sieve.length)
@@ -54,7 +54,6 @@ object Primes:
         i += 1
       sieve = newSieve
     sieve(n)
-  }
 
   // stream of cached sieved primes
   val primes: LazyList[Int] = LazyList.from(2).filter(isSievedPrime)

--- a/src/test/scala/net/tisue/euler/102.scala
+++ b/src/test/scala/net/tisue/euler/102.scala
@@ -15,8 +15,9 @@ class Problem102 extends Problem(102, "228"):
   def solve =
     io.Source.fromResource("102.txt").getLines
       .map(_.trim.split(",").toList.map(_.toInt))
-      .filter{case Seq(x1, y1, x2, y2, x3, y3): Seq[Int] @unchecked =>
-                check(x1, y1, x2, y2, x3, y3) &&
-                check(x2, y2, x1, y1, x3, y3) &&
-                check(x3, y3, x1, y1, x2, y2)}
+      .filter:
+        case Seq(x1, y1, x2, y2, x3, y3): Seq[Int] @unchecked =>
+          check(x1, y1, x2, y2, x3, y3) &&
+            check(x2, y2, x1, y1, x3, y3) &&
+            check(x3, y3, x1, y1, x2, y2)
       .size

--- a/src/test/scala/net/tisue/euler/103.scala
+++ b/src/test/scala/net/tisue/euler/103.scala
@@ -15,16 +15,16 @@ class Problem103 extends Problem(103, "20313839404245"):
     if ss.isEmpty then
       List(List(x))
     else
-      val middle = ss.sliding(2).collect{case List(l1, l2) => l2 ++ l1.map(_ + x)}
+      val middle = ss.sliding(2).collect:
+        case List(l1, l2) => l2 ++ l1.map(_ + x)
       (ss.head :+ x) +: middle.toList :+ List(ss.head.sum + x)
   def isSpecial(ss: SumSet): Boolean =
-    ss.size < 2 || ss.sliding(2).forall{
+    ss.size < 2 || ss.sliding(2).forall:
       case List(xs1, xs2) =>
         xs1.size == xs1.distinct.size &&
         xs2.size == xs2.distinct.size &&
         xs1.last < xs2.head
       case _ => throw IllegalStateException()
-    }
   def solve =
     val solutions =
       for

--- a/src/test/scala/net/tisue/euler/104.scala
+++ b/src/test/scala/net/tisue/euler/104.scala
@@ -7,7 +7,8 @@ class Problem104 extends Problem(104, "329468"):
   import java.math.{ BigDecimal, MathContext }
   lazy val fibLastNines: LazyList[Int] =
     0 #:: 1 #::
-      fibLastNines.zip(fibLastNines.tail).map{case (f1, f2) => (f1 + f2) % 1000000000}
+      fibLastNines.zip(fibLastNines.tail).map:
+        case (f1, f2) => (f1 + f2) % 1000000000
   // en.wikipedia.org/wiki/Fibonacci_number#Computation_by_rounding
   def fibFirstNine(k: Int) =
     BigDecimal((1 + math.sqrt(5d)) / 2)
@@ -18,6 +19,7 @@ class Problem104 extends Problem(104, "329468"):
     ns.sum == 45 && ns.product == 362880
   def solve =
     fibLastNines.zipWithIndex
-      .collect{case (f, k) if isPandigital(f.digits) => k}
+      .collect:
+        case (f, k) if isPandigital(f.digits) => k
       .find(k => isPandigital(fibFirstNine(k)))
       .get

--- a/src/test/scala/net/tisue/euler/105.scala
+++ b/src/test/scala/net/tisue/euler/105.scala
@@ -8,15 +8,16 @@ class Problem105 extends Problem(105, "73702"):
     if ss.isEmpty then
       List(List(x))
     else
-      (ss.head :+ x) +: ss.sliding(2).collect{case List(l1, l2) => l2 ++ l1.map(_ + x)}.toList :+ List(ss.head.sum + x)
+      val middle = ss.sliding(2).collect:
+        case List(l1, l2) => l2 ++ l1.map(_ + x)
+      (ss.head :+ x) +: middle.toList :+ List(ss.head.sum + x)
   def isSpecial(ss: SumSet): Boolean =
-    ss.size < 2 || ss.sliding(2).forall{
+    ss.size < 2 || ss.sliding(2).forall:
       case List(xs1, xs2) =>
         xs1.size == xs1.distinct.size &&
         xs2.size == xs2.distinct.size &&
         xs1.last < xs2.head
       case _ => throw IllegalStateException()
-    }
   def solve =
     io.Source.fromResource("105.txt").getLines
       .map(_.split(",").map(_.toInt).sorted)

--- a/src/test/scala/net/tisue/euler/107.scala
+++ b/src/test/scala/net/tisue/euler/107.scala
@@ -28,24 +28,25 @@ class Problem107 extends Problem(107, "259679"):
         throw Found
       else if visited(v) then
         visited
-      else net.keys.foldLeft(visited + v){(visited, edge) =>
-          edge match
-            case (`v`, other) => traverse(other, visited)
-            case (other, `v`) => traverse(other, visited)
-            case _ => visited
-        }
+      else
+        net.keys.foldLeft(visited + v):
+          (visited, edge) =>
+            edge match
+              case (`v`, other) => traverse(other, visited)
+              case (other, `v`) => traverse(other, visited)
+              case _ => visited
     try
       traverse(edge._1)
       false
     catch case Found => true
   def minimize[T](net: Network[T]) =
     val sortedEdges = net.toSeq.sortBy(_._2).reverse.map(_._1)
-    sortedEdges.foldLeft(net){(net, edge) =>
-      val erased = net - edge
-      if pathExists(edge, erased)
-      then erased
-      else net
-    }
+    sortedEdges.foldLeft(net):
+      (net, edge) =>
+        val erased = net - edge
+        if pathExists(edge, erased)
+        then erased
+        else net
   def weight[T](net: Network[T]) =
     net.values.sum
   def solve =

--- a/src/test/scala/net/tisue/euler/11.scala
+++ b/src/test/scala/net/tisue/euler/11.scala
@@ -13,8 +13,9 @@ class Problem11 extends Problem(11, "70600674"):
           j <- 0 until a.size  // try all starting points
           (xdir, ydir) <- directions
           coords = (0 to 3).map(distance => (i + distance * xdir, j + distance * ydir)) // compute coords of four numbers
-          if coords.forall{case (i, j) => inBounds(i) && inBounds(j)} // are all coords in bounds?
-          product = coords.map{case (i, j) => a(i)(j)}.product // compute product
-      yield product
+          if coords.forall:
+            case (i, j) => inBounds(i) && inBounds(j) // are all coords in bounds?
+          products = coords.map:
+            case (i, j) => a(i)(j)
+      yield products.product
     products.max
-

--- a/src/test/scala/net/tisue/euler/114.scala
+++ b/src/test/scala/net/tisue/euler/114.scala
@@ -6,11 +6,12 @@ import Memo.memoize
 
 class Problem114 extends Problem(114, "16475640049"):
   def solve(min: Int, lim: Int) =
-    lazy val count: Int => Long = memoize{start =>
-      val results =
-        for position <- start to lim - min
-            size <- min to lim - position
-        yield count(position + size + 1)
-      1 + results.sum}
+    lazy val count: Int => Long = memoize:
+      start =>
+        val results =
+          for position <- start to lim - min
+              size <- min to lim - position
+          yield count(position + size + 1)
+        1 + results.sum
     count(0)
   def solve = solve(3, 50)

--- a/src/test/scala/net/tisue/euler/115.scala
+++ b/src/test/scala/net/tisue/euler/115.scala
@@ -5,12 +5,13 @@ import Memo.memoize
 
 class Problem115 extends Problem(115, "168"):
   def solve(min: Int, lim: Int) =
-    lazy val count: Int => Long = memoize{start =>
-      val results =
-        for{position <- start to lim - min
-            size <- min to lim - position}
-        yield count(position + size + 1)
-      1 + results.sum}
+    lazy val count: Int => Long = memoize:
+      start =>
+        val results =
+          for position <- start to lim - min
+              size <- min to lim - position
+          yield count(position + size + 1)
+        1 + results.sum
     count(0)
   def solve =
     def tooSmall(n: Int) = solve(50, n) <= 1000000

--- a/src/test/scala/net/tisue/euler/116.scala
+++ b/src/test/scala/net/tisue/euler/116.scala
@@ -5,12 +5,12 @@ import Memo.memoize
 
 class Problem116 extends Problem(116, "20492570929"):
   def solve(size: Int, tileSize: Int) =
-    lazy val count: Int => Long = memoize{start =>
-      val results =
-        for position <- start to size - tileSize
-        yield 1 + count(position + tileSize)
-      results.sum
-    }
+    lazy val count: Int => Long = memoize:
+      start =>
+        val results =
+          for position <- start to size - tileSize
+          yield 1 + count(position + tileSize)
+        results.sum
     count(0)
   def solve = (2 to 4).map(solve(50, _)).sum
 

--- a/src/test/scala/net/tisue/euler/122.scala
+++ b/src/test/scala/net/tisue/euler/122.scala
@@ -55,7 +55,7 @@ class Problem122Functional extends Problem(122, "1582"):
   def solve =
     val start = (List(BitSet(1)), Map[Int, Int]())
     Iterator.iterate(start)(Function.tupled(iterate))
-      .collectFirst{
+      .collectFirst:
         case (cur, m) if cur.isEmpty =>
           m.values.map(_ - 1).sum
-      }.get
+      .get

--- a/src/test/scala/net/tisue/euler/191.scala
+++ b/src/test/scala/net/tisue/euler/191.scala
@@ -3,13 +3,13 @@ import Memo.memoize
 
 class Problem191 extends Problem(191, "1918080160"):
   val count: (Int, Int, Boolean) => Int =
-    memoize{(days, consecutiveAbsents, hasBeenLate) =>
-      if consecutiveAbsents >= 3 then 0
-      else if days == 30 then 1
-      else
-        val L = if hasBeenLate then 0 else count(days + 1, 0, true)
-        val O = count(days + 1, 0, hasBeenLate)
-        val A = count(days + 1, consecutiveAbsents + 1, hasBeenLate)
-        L + O + A
-    }
+    memoize:
+      (days, consecutiveAbsents, hasBeenLate) =>
+        if consecutiveAbsents >= 3 then 0
+        else if days == 30 then 1
+        else
+          val L = if hasBeenLate then 0 else count(days + 1, 0, true)
+          val O = count(days + 1, 0, hasBeenLate)
+          val A = count(days + 1, consecutiveAbsents + 1, hasBeenLate)
+          L + O + A
   def solve = count(0, 0, false)

--- a/src/test/scala/net/tisue/euler/21.scala
+++ b/src/test/scala/net/tisue/euler/21.scala
@@ -14,8 +14,9 @@ class Problem21 extends Problem(21, "31626"):
   def divisorSum(n: Int) =
     (1 to n / 2).filter(n % _ == 0).sum
   val solutions =
-    (2 until 10000).filter{n =>
-      val sum = divisorSum(n)
-      n != sum && n == divisorSum(sum)}
+    (2 until 10000).filter:
+      n =>
+        val sum = divisorSum(n)
+        n != sum && n == divisorSum(sum)
   def solve = solutions.sum
 

--- a/src/test/scala/net/tisue/euler/39.scala
+++ b/src/test/scala/net/tisue/euler/39.scala
@@ -1,8 +1,8 @@
 package net.tisue.euler
 
 // If p is the perimeter of a right angle triangle with integral
-// length sides, {a,b,c}, there are exactly three solutions for p =
-// 120: {20,48,52}, {24,45,51}, {30,40,50}
+// length sides, (a,b,c), there are exactly three solutions for p =
+// 120: (20,48,52), (24,45,51), (30,40,50)
 // For which value of p < 1000, is the number of solutions maximised?
 
 class Problem39 extends Problem(39, "840"):

--- a/src/test/scala/net/tisue/euler/46.scala
+++ b/src/test/scala/net/tisue/euler/46.scala
@@ -11,7 +11,10 @@ class Problem46 extends Problem(46, "5777"):
     n == square(math.round(math.sqrt(n)).toInt)
   def hasSolution(n: Int) =
     primes.takeWhile(_ < n)
-      .exists{p => val diff = n - p; diff % 2 == 0 && isSquare(diff / 2)}
+      .exists:
+        p =>
+          val diff = n - p
+          diff % 2 == 0 && isSquare(diff / 2)
   def solve =
     LazyList.from(3, 2)
       .find(n => !isSievedPrime(n) && !hasSolution(n))

--- a/src/test/scala/net/tisue/euler/54.scala
+++ b/src/test/scala/net/tisue/euler/54.scala
@@ -47,7 +47,9 @@ class Problem54 extends Problem(54, solution = "376"):
       hand.map(_.rank)
         .sorted
         .sliding(2)
-        .forall{case Seq(r1, r2) : Seq[Int] @unchecked => r2 == r1 + 1}
+        .forall:
+          case Seq(r1, r2) : Seq[Int] @unchecked =>
+            r2 == r1 + 1
     val handFunctions =
       IndexedSeq(
         () => isNOfAKind(1),
@@ -76,5 +78,6 @@ class Problem54 extends Problem(54, solution = "376"):
       for line <- io.Source.fromResource("54.txt").getLines.toList
           cards = line.split(" ").toList.map(readCard)
       yield cards.splitAt(5)
-    input.count{case (hand1, hand2) =>
-      beats(hand1, hand2)}
+    input.count:
+      case (hand1, hand2) =>
+        beats(hand1, hand2)

--- a/src/test/scala/net/tisue/euler/57.scala
+++ b/src/test/scala/net/tisue/euler/57.scala
@@ -6,8 +6,12 @@ package net.tisue.euler
 
 class Problem57 extends Problem(57, "153"):
   def solve =
-    LazyList.iterate((BigInt(2), BigInt(1))){case (n, d) => (d + n * 2, n)}
-      .drop(1).take(1000)
-      .map{case (n, d) => (n - d, d)}
-      .count{case (n, d) => n.toString.size > d.toString.size}
-
+    LazyList
+      .iterate((BigInt(2), BigInt(1))):
+        case (n, d) => (d + n * 2, n)
+      .drop(1)
+      .take(1000)
+      .map:
+        case (n, d) => (n - d, d)
+      .count:
+        case (n, d) => n.toString.size > d.toString.size

--- a/src/test/scala/net/tisue/euler/59.scala
+++ b/src/test/scala/net/tisue/euler/59.scala
@@ -13,7 +13,10 @@ class Problem59 extends Problem(59, "107359"):
     (s.split(' ').size / s.size.toDouble) > 0.15
   def decrypt(s: String, key: Seq[Char]) =
     s.to(LazyList).zip(key.to(LazyList).circular)
-     .map{case (c1, c2) => c1 ^ c2}.map(_.toChar).mkString
+     .map:
+       case (c1, c2) => c1 ^ c2
+     .map(_.toChar)
+     .mkString
   val cipherText =
     io.Source.fromResource("59.txt").mkString.trim.split(",").map(_.toInt.toChar).mkString
   val allKeys =
@@ -30,8 +33,7 @@ class Problem59 extends Problem(59, "107359"):
 a less janky way to write isEnglish, assuming you have a dictionary available:
   val dict = io.Source.fromFile("/usr/share/dict/words")("ISO-8859-1")
                .getLines.map(_.trim.toLowerCase).toSet
-  def isEnglish(s: String): Boolean = {
+  def isEnglish(s: String): Boolean =
     val words = s.toLowerCase.filter((c:Char) => c == ' ' || c.isLetter).mkString.split(' ')
     0.5 < words.count(dict.contains(_)) / words.size.toDouble
-  }
 */

--- a/src/test/scala/net/tisue/euler/68.scala
+++ b/src/test/scala/net/tisue/euler/68.scala
@@ -8,7 +8,7 @@ class Problem68 extends Problem(68, "6531031914842725"):
     ns(0) < ns(3) &&
       ns(0) < ns(5) &&
       ns(0) < ns(7) &&
-      ns(0) < ns(9) && locally:
+      ns(0) < ns(9) && :
         val sum = ns(0) + ns(1) + ns(2)
         sum == ns(3) + ns(2) + ns(4) &&
           sum == ns(5) + ns(4) + ns(6) &&

--- a/src/test/scala/net/tisue/euler/68.scala
+++ b/src/test/scala/net/tisue/euler/68.scala
@@ -8,13 +8,12 @@ class Problem68 extends Problem(68, "6531031914842725"):
     ns(0) < ns(3) &&
       ns(0) < ns(5) &&
       ns(0) < ns(7) &&
-      ns(0) < ns(9) && {
+      ns(0) < ns(9) && locally:
         val sum = ns(0) + ns(1) + ns(2)
         sum == ns(3) + ns(2) + ns(4) &&
           sum == ns(5) + ns(4) + ns(6) &&
           sum == ns(7) + ns(6) + ns(8) &&
           sum == ns(9) + ns(8) + ns(1)
-      }
   def expand(ns: IndexedSeq[Int]) =
     Seq(ns(0), ns(1), ns(2), ns(3), ns(2), ns(4),
         ns(5), ns(4), ns(6), ns(7), ns(6), ns(8),

--- a/src/test/scala/net/tisue/euler/71.scala
+++ b/src/test/scala/net/tisue/euler/71.scala
@@ -9,7 +9,9 @@ class Problem71 extends Problem(71, "428570"):
   def solve =
    (1 to 1000000)
      .map(d => (d * 3 / 7, d))
-     .filter{case (n, d) => n * 7 != d * 3}
-     .maxBy{case (n, d) => n.toDouble / d}
+     .filter:
+       case (n, d) => n * 7 != d * 3
+     .maxBy:
+       case (n, d) => n.toDouble / d
      ._1
 

--- a/src/test/scala/net/tisue/euler/78.scala
+++ b/src/test/scala/net/tisue/euler/78.scala
@@ -22,7 +22,8 @@ class Problem78 extends Problem(78, "55374"):
                                          n - (k * k * 3 + k) / 2))
         .takeWhile(_ >= 0)
         .zip(LazyList(1, 1, -1, -1).circular)
-        .map{case (j, sign) => memo(j) * sign}
+        .map:
+          case (j, sign) => memo(j) * sign
         .sum % 1000000
     memo.last
   def solve = LazyList.from(1).find(p(_) == 0).get

--- a/src/test/scala/net/tisue/euler/80.scala
+++ b/src/test/scala/net/tisue/euler/80.scala
@@ -26,11 +26,15 @@ class Problem80 extends Problem(80, "40886"):
   def digitalSum(d: BigDecimal) =
     d.toString.filter(_.isDigit).take(digits).map(_.asDigit).sum
   def firstDuplicate[A](xs: Seq[A]) =
-    xs.zip(xs.tail).find{case (d1, d2) => d1 == d2}.get._1
+    xs.zip(xs.tail)
+      .find:
+        case (d1, d2) => d1 == d2
+      .get._1
   def babylonian(n: BigDecimal) =
-    LazyList.iterate(n){next =>
-      ((next + roundingDivide(n, next)) / 2)
-        .setScale(digits, S.DOWN)}
+    LazyList.iterate(n):
+      next =>
+        ((next + roundingDivide(n, next)) / 2)
+          .setScale(digits, S.DOWN)
   def solve =
     (1 to 100)
       .filter(!isSquare(_))

--- a/src/test/scala/net/tisue/euler/82.scala
+++ b/src/test/scala/net/tisue/euler/82.scala
@@ -14,12 +14,11 @@ class Problem82 extends Problem(82, "260324"):
     // rather than (x,y), but oh well
     for x <- range.reverse.drop(1)
         y <- range
-      do matrix(y)(x) = {
+      do matrix(y)(x) = locally:
         val down = if y == 0 then Integer.MAX_VALUE
                    else matrix(y - 1)(x) + matrix(y)(x)
         val up =
           (y until matrix.size).map(y2 =>
             (y to y2).map(matrix(_)(x)).sum + matrix(y2)(x + 1))
         down min up.min
-      }
     range.map(matrix(_)(0)).min

--- a/src/test/scala/net/tisue/euler/82.scala
+++ b/src/test/scala/net/tisue/euler/82.scala
@@ -14,7 +14,7 @@ class Problem82 extends Problem(82, "260324"):
     // rather than (x,y), but oh well
     for x <- range.reverse.drop(1)
         y <- range
-      do matrix(y)(x) = locally:
+      do matrix(y)(x) =
         val down = if y == 0 then Integer.MAX_VALUE
                    else matrix(y - 1)(x) + matrix(y)(x)
         val up =

--- a/src/test/scala/net/tisue/euler/84.scala
+++ b/src/test/scala/net/tisue/euler/84.scala
@@ -63,7 +63,7 @@ class Problem84 extends Problem(84, solution = "101524"):
         nexts.size * die * die))
 
   // P is the Markov matrix
-  val P: List[List[Double]] = locally:
+  val P: List[List[Double]] =
     val zeroVector = List.fill(names.size)(BigRational(0))
     val rolls =
       for die1 <- 1 to die

--- a/src/test/scala/net/tisue/euler/84.scala
+++ b/src/test/scala/net/tisue/euler/84.scala
@@ -63,17 +63,17 @@ class Problem84 extends Problem(84, solution = "101524"):
         nexts.size * die * die))
 
   // P is the Markov matrix
-  val P: List[List[Double]] = {
+  val P: List[List[Double]] = locally:
     val zeroVector = List.fill(names.size)(BigRational(0))
     val rolls =
       for die1 <- 1 to die
           die2 <- 1 to die
       yield die1 + die2
     def row(i: Int): List[BigRational] =
-      rolls.toList.foldLeft(zeroVector){(vec, roll) =>
-        vec.lazyZip(nextSquare(i, roll)).map(_ + _)}
+      rolls.toList.foldLeft(zeroVector):
+        (vec, roll) =>
+          vec.lazyZip(nextSquare(i, roll)).map(_ + _)
     names.indices.toList.map(row(_).map(_.toDouble))
-  }
 
   def matrixMul(m1: List[List[Double]], m2: List[List[Double]]) =
     val indices = m1.indices.toList

--- a/src/test/scala/net/tisue/euler/86.scala
+++ b/src/test/scala/net/tisue/euler/86.scala
@@ -50,16 +50,14 @@ class Problem86 extends Problem(86, "1818"):
       // changes.
       def cuboidCount: Int =
         (b min (a / 2)) - (1 max (a - b)) + 1
-    val primitiveTriples = {
+    val primitiveTriples = locally:
       given Ordering[Triple] = Ordering.by[Triple, Int](_.b).reverse
       val heap = collection.mutable.PriorityQueue[Triple]()
       heap += Triple(3, 4, 5)
-      LazyList.continually {
+      LazyList.continually:
         val result = heap.dequeue()
         heap ++= result.children.map(_.canonical)
         result
-      }
-    }
 
     // this gives us all the triples (primitive or not) where either leg
     // equals m and the other leg is at most 2m (since to fit cuboids

--- a/src/test/scala/net/tisue/euler/86.scala
+++ b/src/test/scala/net/tisue/euler/86.scala
@@ -50,7 +50,7 @@ class Problem86 extends Problem(86, "1818"):
       // changes.
       def cuboidCount: Int =
         (b min (a / 2)) - (1 max (a - b)) + 1
-    val primitiveTriples = locally:
+    val primitiveTriples =
       given Ordering[Triple] = Ordering.by[Triple, Int](_.b).reverse
       val heap = collection.mutable.PriorityQueue[Triple]()
       heap += Triple(3, 4, 5)

--- a/src/test/scala/net/tisue/euler/89.scala
+++ b/src/test/scala/net/tisue/euler/89.scala
@@ -11,15 +11,15 @@ class Problem89 extends Problem(89, "743"):
     ("M", 1000), ("CM", 900), ("D", 500), ("CD", 400), ("C", 100), ("XC", 90),
     ("L", 50), ("XL", 40), ("X", 10), ("IX", 9), ("V", 5), ("IV", 4), ("I", 1))
   def arabic(s: String): Int =
-    key.collectFirst{
+    key.collectFirst:
       case (letters, number) if s.startsWith(letters) =>
         number + arabic(s.drop(letters.size))
-    }.getOrElse(0)
+    .getOrElse(0)
   def roman(n: Int): String =
-    key.collectFirst{
+    key.collectFirst:
       case (letters, number) if number <= n =>
         letters + roman(n - number)
-    }.getOrElse("")
+    .getOrElse("")
   def solve =
     io.Source.fromResource("89.txt")
       .getLines.map(_.trim)

--- a/src/test/scala/net/tisue/euler/91.scala
+++ b/src/test/scala/net/tisue/euler/91.scala
@@ -12,13 +12,12 @@ class Problem91 extends Problem(91, "14234"):
     math.abs(d1 - d2) < 0.00000000001
   case class Triangle(x1: Int, y1: Int, x2: Int, y2: Int)
   def isSolution(t: Triangle) =
-    val List(side0, side1, side2): @unchecked = {
+    val List(side0, side1, side2): @unchecked = locally:
       import Ordering.Double.TotalOrdering
       List(distance(t.x1, t.y1, t.x2, t.y2),
            distance(t.x1, t.y1, 0, 0),
            distance(t.x2, t.y2, 0, 0))
         .sorted.reverse
-    }
     near(square(side0), square(side1) + square(side2)) &&
       !near(side0, side1 + side2)
   def candidates =

--- a/src/test/scala/net/tisue/euler/91.scala
+++ b/src/test/scala/net/tisue/euler/91.scala
@@ -12,7 +12,7 @@ class Problem91 extends Problem(91, "14234"):
     math.abs(d1 - d2) < 0.00000000001
   case class Triangle(x1: Int, y1: Int, x2: Int, y2: Int)
   def isSolution(t: Triangle) =
-    val List(side0, side1, side2): @unchecked = locally:
+    val List(side0, side1, side2): @unchecked =
       import Ordering.Double.TotalOrdering
       List(distance(t.x1, t.y1, t.x2, t.y2),
            distance(t.x1, t.y1, 0, 0),

--- a/src/test/scala/net/tisue/euler/94.scala
+++ b/src/test/scala/net/tisue/euler/94.scala
@@ -14,6 +14,8 @@ class Problem94 extends Problem(94, "518408346"):
   def solve =
     val candidates = 3L to (1000000000L / 6)
     type Filter = PartialFunction[Long, Long]
-    val filter1: Filter = {case n if isSquare(3 * n * n - 4 * n + 1) => 6 * n - 2}
-    val filter2: Filter = {case n if isSquare(3 * n * n + 4 * n + 1) => 6 * n + 2}
+    val filter1: Filter =
+      case n if isSquare(3 * n * n - 4 * n + 1) => 6 * n - 2
+    val filter2: Filter =
+      case n if isSquare(3 * n * n + 4 * n + 1) => 6 * n + 2
     candidates.collect(filter1).sum + candidates.collect(filter2).sum

--- a/src/test/scala/net/tisue/euler/95.scala
+++ b/src/test/scala/net/tisue/euler/95.scala
@@ -12,10 +12,15 @@ class Problem95 extends Problem(95, "14316"):
   // mathworld.wolfram.com/DivisorFunction.html
   def properDivisorSum(n: Int): Int =
     if n == 1 then 1
-    else factors(n).group.map{fs => val factor = fs.head.toLong
-                                    val exponent = fs.size
-                                    (List.fill(exponent + 1)(factor).product - 1) / (factor - 1)}
-                         .product.toInt - n
+    else
+      factors(n)
+        .group
+        .map:
+          fs =>
+            val factor = fs.head.toLong
+            val exponent = fs.size
+            (List.fill(exponent + 1)(factor).product - 1) / (factor - 1)
+        .product.toInt - n
   val chain: Int => LazyList[Int] = memoize(n =>
     n #:: chain(properDivisorSum(n)))
   // This part isn't very elegant. I'm not sure how to do better.

--- a/src/test/scala/net/tisue/euler/96.scala
+++ b/src/test/scala/net/tisue/euler/96.scala
@@ -26,7 +26,7 @@ class Problem96 extends Problem(96, "24702"):
   type Puzzle = List[List[Int]]  // 9 lists of 9 integers in 1-9 range
   type Group = List[Int]         // 9 integers in 0-80 range
 
-  val groups: List[Group] = {
+  val groups: List[Group] = locally:
     val rows    = for i <- (0 to 8).toList
                   yield (0 to 80).toList.filter(_ / 9 == i)
     val columns = for i <- (0 to 8).toList
@@ -34,7 +34,6 @@ class Problem96 extends Problem(96, "24702"):
     val boxes   = for i <- (0 to 2).toList; j <- 0 to 2
                   yield (0 to 80).toList.filter(n => n / 27 == i && n % 9 / 3 == j)
     rows ::: columns ::: boxes
-  }
 
   // from initial guess x0, iterate until we find x such that fn(x) = x
   def fixedPoint[A](x0: A)(fn: (A) => A): A =
@@ -49,28 +48,32 @@ class Problem96 extends Problem(96, "24702"):
   // makes a guess, solve2 and solve1 must be run to exhaustion.
 
   def solve1(puzzle: Puzzle) =
-    groups.foldLeft(puzzle){(puzzle, group) =>
-      val usedDigits = group.map(puzzle(_)).filter(_.size == 1).map(_.head)
-      puzzle.zipWithIndex.map{case (entry, index) =>
-        if !group.contains(index) || entry.size == 1 then
-          entry
-        else
-          entry.filter(!usedDigits.contains(_))}}
+    groups.foldLeft(puzzle):
+      (puzzle, group) =>
+        val usedDigits = group.map(puzzle(_)).filter(_.size == 1).map(_.head)
+        puzzle.zipWithIndex.map:
+          case (entry, index) =>
+            if !group.contains(index) || entry.size == 1
+            then entry
+            else entry.filter(!usedDigits.contains(_))
 
   def solve2(puzzle: Puzzle) =
-    groups.foldLeft(puzzle){(puzzle, group) =>
-      val v =
-        (1 to 9)
-          .filter(d => group.filter(puzzle(_).size > 1)
-                         .flatMap(puzzle(_))
-                         .count(_ == d) == 1)
-      v.foldLeft(puzzle){(puzzle, d) =>
-        val start =
-          puzzle.zipWithIndex.map{case (entry, index) =>
-            if group.contains(index) && entry.contains(d) then
-              List(d)
-            else entry}
-        fixedPoint(start)(solve1)}}
+    groups.foldLeft(puzzle):
+      (puzzle, group) =>
+        val v =
+          (1 to 9)
+            .filter(d => group.filter(puzzle(_).size > 1)
+                           .flatMap(puzzle(_))
+                           .count(_ == d) == 1)
+        v.foldLeft(puzzle):
+          (puzzle, d) =>
+            val start =
+              puzzle.zipWithIndex.map:
+                case (entry, index) =>
+                  if group.contains(index) && entry.contains(d)
+                  then List(d)
+                  else entry
+            fixedPoint(start)(solve1)
 
   def solve1and2(puzzle: Puzzle) =
     fixedPoint(fixedPoint(puzzle)(solve1))(solve2)
@@ -87,8 +90,8 @@ class Problem96 extends Problem(96, "24702"):
           Some(puzzle)
         case index =>
           puzzle(index)
-            .flatMap{guess =>
-              solve3(fixedPoint(puzzle.updated(index, List(guess)))(solve1and2))}
+            .flatMap:
+              guess => solve3(fixedPoint(puzzle.updated(index, List(guess)))(solve1and2))
             .headOption
 
   val puzzles: Iterator[Puzzle] =

--- a/src/test/scala/net/tisue/euler/96.scala
+++ b/src/test/scala/net/tisue/euler/96.scala
@@ -26,7 +26,7 @@ class Problem96 extends Problem(96, "24702"):
   type Puzzle = List[List[Int]]  // 9 lists of 9 integers in 1-9 range
   type Group = List[Int]         // 9 integers in 0-80 range
 
-  val groups: List[Group] = locally:
+  val groups: List[Group] =
     val rows    = for i <- (0 to 8).toList
                   yield (0 to 80).toList.filter(_ / 9 == i)
     val columns = for i <- (0 to 8).toList

--- a/src/test/scala/net/tisue/euler/Problem.scala
+++ b/src/test/scala/net/tisue/euler/Problem.scala
@@ -2,6 +2,5 @@ package net.tisue.euler
 
 abstract class Problem(number: Int, solution: String) extends munit.FunSuite:
   def solve: Any
-  test(s"problem $number") {
+  test(s"problem $number"):
     assert(solution == solve.toString)
-  }


### PR DESCRIPTION
not sure whether to actually merge this, or just keep it around as a reference for eventual discussions about the status of `-Yindent-colons`, post-3.0

I guess for now I'll just leave it around as a draft

Gitter discussion about how this went: https://gitter.im/lampepfl/dotty?at=5fc1a02c8292a93eb1029c7d

I should maybe turn all this into a thread on https://contributors.scala-lang.org at some point.... maybe wait until after 3.0 ships?