### PR TITLE
use AdoptOpenJDK instead of Zulu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
     - uses: coursier/cache-action@v6
     - uses: actions/setup-java@v1
       with:
+        distribution: adopt
         java-version: ${{matrix.java}}
     - name: Test
       # keep heap usage down by running tests serially

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     - run: git config --global core.autocrlf false  # for Windows
     - uses: actions/checkout@v2
     - uses: coursier/cache-action@v6
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v2
       with:
         distribution: adopt
         java-version: ${{matrix.java}}


### PR DESCRIPTION
at Lightbend we normally use AdoptOpenJDK, for whatever reason