### PR TITLE
only test on JDK 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - java: 8
-            os: ubuntu-latest
-          - java: 11
-            os: ubuntu-latest
           - java: 17
             os: ubuntu-latest
-          - java: 8
+          - java: 17
             os: windows-latest
     runs-on: ${{matrix.os}}
     steps:

--- a/.jvmopts
+++ b/.jvmopts
@@ -1,2 +1,2 @@
--Xmx8G
+-Xmx6G
 -XX:MaxInlineLevel=18


### PR DESCRIPTION
it's about time to toss JDK 8 in the dustbin of history, and why not also skip 11...

but note that after this change GitHub Actions on Windows won't accept an 8GB heap 🤷 